### PR TITLE
Setup proxy mode to allow HTTPS traffic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ __pycache__/
 *.egg-info
 # emacs backup files
 *~
+# vim backup files
+.*.sw[a-z]
 # hg stuff
 *.orig
 status

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # -----------------------------------------------------------------------------
 # BUILDING IMAGE
 FROM		python:3.9.4-alpine as builder
+MAINTAINER	Manuel F Martinez <manuel@wishpond.com>
 
 		# Set working directory
 WORKDIR		/odoo
@@ -26,14 +27,11 @@ RUN		apk add --no-cache postgresql-libs wkhtmltopdf
 		# Copy the built dependencies
 COPY		--from=builder /build /usr/local
 
-		# Configuration file
-ADD		./deployment/docker/odoo.conf /etc/odoo/
-
 		# Do not run as root!
 RUN 		addgroup -S odoo && \
 		adduser -S -D -G odoo odoo && \
-		mkdir -p /mnt/extra-addons /var/lib/odoo && \
-		chown -R odoo:odoo /mnt/extra-addons /var/lib/odoo /home/odoo /etc/odoo/odoo.conf
+		mkdir -p /mnt/extra-addons /var/lib/odoo /etc/odoo && \
+		chown -R odoo:odoo /mnt/extra-addons /var/lib/odoo /home/odoo /etc/odoo
 
 		# User volumes
 VOLUME		["/var/lib/odoo", "/mnt/extra-addons"]

--- a/deployment/docker/default.conf
+++ b/deployment/docker/default.conf
@@ -1,0 +1,23 @@
+server {
+  listen 80;
+
+  # Add Headers for odoo proxy mode
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Real-IP $remote_addr;
+
+  location /elb {
+    default_type application/json;
+    return 200 '{"code":"200", "http": "OK"}';
+  }
+
+  location / {
+    proxy_pass         http://crm:8069;
+    proxy_redirect     off;
+  }
+
+  # Common gzip
+  gzip_types text/css text/scss text/plain text/xml application/xml application/json application/javascript;
+  gzip on;
+}

--- a/deployment/docker/odoo.conf
+++ b/deployment/docker/odoo.conf
@@ -1,6 +1,7 @@
 [options]
 addons_path = /mnt/extra-addons
 data_dir = /var/lib/odoo
+proxy_mode = True
 ; admin_passwd = admin
 ; csv_internal_sep = ,
 ; db_maxconn = 64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     build: ./
     depends_on:
       - postgres
-    ports:
-      - "80:8069"
     environment:
       - PGHOST=postgres
       - PGUSER=crm
@@ -15,6 +13,14 @@ services:
     volumes:
       - wishpond_crm:/var/lib/odoo
       - ./deployment/docker/odoo.conf:/etc/odoo/odoo.conf
+
+  proxy:
+    container_name: wishpond_proxy_crm
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./deployment/docker/default.conf:/etc/nginx/conf.d/default.conf
 
   postgres:
     container_name: wishpond_postgres


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Currently a plain deployment of Odoo will deliver content in plain HTTP.
In order to serve HTTPS traffic, `proxy_mode` must be enabled in the configuration file, and a transparent proxy must sit in front of the application.

Current behavior before PR:
Odoo serves plain traffic on port 8069 and is unable to redirect/serve traffic to port 443/HTTPS

Desired behavior after PR is merged:
Odoo must be able to handle properly HTTP and HTTPS traffic correctly when getting traffic from an HTTPS proxy and/or LB.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
